### PR TITLE
1.2.1

### DIFF
--- a/lib/parity.js
+++ b/lib/parity.js
@@ -1,4 +1,4 @@
-const Parity = require('parity-spawn')
+const Parity = require('openethereum-spawn')
 const Nanoeth = require('nanoeth/ipc')
 const fs = require('fs').promises
 const path = require('path')
@@ -7,7 +7,7 @@ const os = require('os')
 module.exports = async function (fn) {
   const p = new Parity({
     port: '39393',
-    parityExec: require('parity-binary'),
+    parityExec: require('openethereum-binary'),
     basePath: await fs.mkdtemp(path.join(os.tmpdir(), 'tape-parity-')),
     light: false,
     ipc: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tape-parity",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Tape extension that adds a Parity dev chain and Nanoeth helpers",
   "main": "index.js",
   "bin": {
@@ -16,14 +16,13 @@
     "eth-sign": "^0.3.4",
     "nanoassert": "^2.0.0",
     "nanoeth": "^2.5.2",
+    "openethereum-binary": "^2.0.4",
     "openethereum-spawn": "^1.0.2",
-    "parity-binary": "^1.0.3",
-    "parity-spawn": "^1.0.0",
+    "resolve": "1.19.0",
     "sodium-native": "^3.2.0",
     "standard": "^14.3.4",
     "tape": "^5.0.1"
   },
-  "devDependencies": {},
   "scripts": {
     "pretest": "standard",
     "test": "node test.js"


### PR DESCRIPTION
Update dependencies
  add pkg `resolve` as an explicit dep
  update from parity- to openethereum- deps

depends on `openethereum-binary` being bumped to `v2.0.4`

depends on https://github.com/hyperdivision/openethereum-binary/pull/1